### PR TITLE
Fix Play.Digits type: int -> string

### DIFF
--- a/vocabulary.go
+++ b/vocabulary.go
@@ -243,7 +243,7 @@ func (p *Pause) Type() string {
 type Play struct {
 	XMLName xml.Name `xml:"Play"`
 	Loop    int      `xml:"loop,attr,omitempty"`
-	Digits  int      `xml:"digits,attr,omitempty"`
+	Digits  string   `xml:"digits,attr,omitempty"`
 	URL     string   `xml:",chardata"`
 }
 


### PR DESCRIPTION
Hi, I noticed a small inconsistency with the `Play` struct and Twilio's spec.  From the [example docs](https://www.twilio.com/docs/api/twiml/play#examples-2):

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<Response>
    <Play digits="wwww3"></Play>
</Response>
```

Since `Digits` is an `int`, encoding this response isn't possible. This pull request fixes `Digits` to be `string` but I should note that this would be a breaking change for anyone using it.

P.S. [twilio-voice](https://github.com/BTBurke/twilio-voice) looks cool! I'm looking at setting it up for myself next. 😆