### PR TITLE
Fix "waitUrlMethod" typo in <Enqueue> verb

### DIFF
--- a/vocabulary.go
+++ b/vocabulary.go
@@ -139,7 +139,7 @@ type Enqueue struct {
 	Action        string   `xml:"action,attr,omitempty"`
 	Method        string   `xml:"method,attr,omitempty"`
 	WaitURL       string   `xml:"waitUrl,attr,omitempty"`
-	WaitURLMethod string   `xml:"waiUrlMethod,attr,omitempty"`
+	WaitURLMethod string   `xml:"waitUrlMethod,attr,omitempty"`
 	WorkflowSid   string   `xml:"workflowSid,attr,omitempty"`
 	QueueName     string   `xml:",chardata"`
 }


### PR DESCRIPTION
The `WaitURLMethod` field on `twiml.Enqueue` had a typo in the XML attribute name. Was `waiUrlMethod`, should be `waitUrlMethod`.