### PR TITLE
Twilio Conference

### DIFF
--- a/validate_test.go
+++ b/validate_test.go
@@ -27,4 +27,18 @@ var _ = Describe("Validators", func() {
 		)
 		Expect(ok).To(Equal(false))
 	})
+
+	It("can validate Sip Callback Events", func() {
+		ok := Validate(AllowedCallbackEvent("initiated ringing answered", SipCallbackEvents))
+		notOk := Validate(AllowedCallbackEvent("initiated ringing fakeevent answered", SipCallbackEvents))
+		Expect(ok).To(Equal(true))
+		Expect(notOk).To(Equal(false))
+	})
+
+	It("can validate Conference Callback Events", func() {
+		ok := Validate(AllowedCallbackEvent("start end join leave mute hold speaker", ConferenceCallbackEvents))
+		notOk := Validate(AllowedCallbackEvent("start end join leave initiated hold speaker", ConferenceCallbackEvents))
+		Expect(ok).To(Equal(true))
+		Expect(notOk).To(Equal(false))
+	})
 })

--- a/vocabulary.go
+++ b/vocabulary.go
@@ -33,6 +33,7 @@ func (c *Client) Type() string {
 // Conference TwiML
 type Conference struct {
 	XMLName                       xml.Name `xml:"Conference"`
+	ConferenceName                string   `xml:",chardata"`
 	Muted                         bool     `xml:"muted,attr,omitempty"`
 	Beep                          string   `xml:"beep,attr,omitempty"`
 	StartConferenceOnEnter        bool     `xml:"startConferenceOnEnter,attr,omitempty"`

--- a/vocabulary.go
+++ b/vocabulary.go
@@ -58,7 +58,7 @@ func (c *Conference) Validate() error {
 		AllowedMethod(c.WaitMethod),
 		OneOfOpt(c.Record, "do-not-record", "record-from-start"),
 		OneOfOpt(c.Trim, "trim-silence", "do-not-trim"),
-		OneOfOpt(c.StatusCallbackEvent, "start", "end", "join", "leave", "mute", "hold"),
+		AllowedCallbackEvent(c.StatusCallbackEvent, ConferenceCallbackEvents),
 		AllowedMethod(c.StatusCallbackMethod),
 		AllowedMethod(c.RecordingStatusCallbackMethod),
 	)
@@ -448,7 +448,7 @@ func (s *Sip) Validate() error {
 	//because valid values can be concatenated
 	ok := Validate(
 		AllowedMethod(s.StatusCallbackMethod),
-		AllowedCallbackEvent(s.StatusCallbackEvent),
+		AllowedCallbackEvent(s.StatusCallbackEvent, SipCallbackEvents),
 		Required(s.Address),
 	)
 	if !ok {


### PR DESCRIPTION
These are improvements to this library's handling of Twilio's TwiML `<Conference>` entity, in order to bring it closer to the spec as documented here: https://www.twilio.com/docs/voice/twiml/conference

## Changes
- Support `ConferenceName` chardata attribute
- Adjust validation of the `statusCallbackEvent` field. It does not consist of a single optional value (as was previously validated by the `OneOfOpt` func), but of an optional space-separated list of event names.