### PR TITLE
Messages can be responses to incoming hooks

### DIFF
--- a/twiml.go
+++ b/twiml.go
@@ -52,7 +52,7 @@ func (r *Response) Validate() error {
 	var errs []error
 	for _, s := range r.Children {
 		switch t := s.Type(); t {
-		case "Enqueue", "Hangup", "Leave", "Pause", "Play", "Record", "Redirect", "Reject", "Say", "Dial", "Gather":
+		case "Enqueue", "Hangup", "Leave", "Pause", "Play", "Record", "Redirect", "Reject", "Say", "Dial", "Gather", "Sms":
 			if childErr := s.Validate(); childErr != nil {
 				errs = append(errs, childErr)
 			}


### PR DESCRIPTION
Use case: Message API hook configured for Twilio number: after firing, we need to respond with another Message.

There's a high chance I'm misunderstanding something, but after this edit, everything seems to work as I'd expect.

Sample code to replicate the issue:

```go
func handleIncomingSMS()func(http.ResponseWriter, *http.Request) {
	return func(w http.ResponseWriter, r *http.Request) {
		inSMS := twiml.Sms{}
		err := twiml.Bind(&inSMS, r)
		if err != nil {
			fmt.Println(err.Error())
		}

		respSMS := twiml.Sms{
			XMLName:        xml.Name{},
			To:             inSMS.From,
			From:           from,
			Text:           "Pong!",
		}

		res := twiml.NewResponse()

		res.Add(&respSMS)

		b, err := res.Encode()
		if err != nil {
			http.Error(w, http.StatusText(502), 502)
			return
		}

		// Write the XML response to the http.ReponseWriter
		if _, err := w.Write(b); err != nil {
			http.Error(w, http.StatusText(502), 502)
			return
		}
	}
}
```