### PR TITLE
Make Play digits optional

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -74,6 +74,10 @@ func Numeric(field string) bool {
 
 // NumericOrWait validates that a string contains only digits 0-9 or the wait key 'w'
 func NumericOrWait(field string) bool {
+	if field == "" {
+		return true
+	}
+
 	matched, err := regexp.MatchString("^[0-9w]+$", field)
 	if err != nil {
 		return false


### PR DESCRIPTION
Right now validation fails on `Play` if you don't include digits. I think this is a mistake. Play is the only one using `NumericOrWait` right now so I just updated it, not sure if we want to rename it to like `OptionalNumericOrWait` or something.

https://www.twilio.com/docs/voice/twiml/play#attributes-digits