### PR TITLE
Remove URL as Required for Play verb

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/BTBurke/twiml
+module github.com/KrisLange/twiml
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KrisLange/twiml
 
-go 1.13
+go 1.17
 
 require (
 	github.com/gorilla/schema v1.1.0

--- a/vocabulary.go
+++ b/vocabulary.go
@@ -332,7 +332,6 @@ type Play struct {
 func (p *Play) Validate() error {
 
 	ok := Validate(
-		Required(p.URL),
 		NumericOrWait(p.Digits),
 	)
 


### PR DESCRIPTION
PR addressing #16 by removing Play.URL as a required field. 