### PR TITLE
Revert module name change and go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/KrisLange/twiml
+module github.com/BTBurke/twiml
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BTBurke/twiml
 
-go 1.17
+go 1.13
 
 require (
 	github.com/gorilla/schema v1.1.0


### PR DESCRIPTION
Hello, looks like a module name change leaked from my fork to the main repo. Reverting the 2 commits that were not related to the Play verb fix.